### PR TITLE
Move from comments to job summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,7 @@ MoSCoW prioritization action to manage label-based requirements prioritization
 ```yml
 name: MoSCoW Prioritization
 
-on:
-  pull_request_target:
-    types: [ labeled, opened, unlabeled, reopened ]
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
-  cancel-in-progress: true
+on: pull_request_target
 
 permissions:
   contents: read
@@ -24,9 +18,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: grevend/moscow-prioritization@v1.2.0
-        with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
+      - uses: grevend/moscow-prioritization@v2.0.0
 ```
 
 _Note: This action requires access to the `GITHUB_TOKEN` to call GitHub's REST API_
@@ -35,7 +27,7 @@ _Note: This action requires access to the `GITHUB_TOKEN` to call GitHub's REST A
 
 Input | Description | Default | Availability
 --- | --- | --- | ---
-token | The workflows `GITHUB_TOKEN` secret | | `>v1.0.0`
+token | The workflows `GITHUB_TOKEN` secret | `${{ github.token }}` | `>v1.0.0`
 wont-have-label | Label to expect on low-priority PRs | `wont have` | `>v1.1.0`
 could-have-label | Label to expect on PRs of little relevance | `could have` | `>v1.1.0`
 should-have-label | Label to expect on non-critical PRs | `should have` | `>v1.1.0`

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ concurrency:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: write
+  issues: read
+  pull-requests: read
 
 jobs:
   check:
@@ -33,11 +33,11 @@ _Note: This action requires access to the `GITHUB_TOKEN` to call GitHub's REST A
 
 ### All options
 
-Input | Description | Default
---- | --- | ---
-token | The workflows `GITHUB_TOKEN` secret |
-wont-have-label | Label to expect on low-priority PRs | `wont have`
-could-have-label | Label to expect on PRs of little relevance | `could have`
-should-have-label | Label to expect on non-critical PRs | `should have`
-must-have-label | Label to expect on essential PRs | `must have`
-fail-if-missing-label | Unprioritized PRs should fail the action | `true`
+Input | Description | Default | Availability
+--- | --- | --- | ---
+token | The workflows `GITHUB_TOKEN` secret | | `>v1.0.0`
+wont-have-label | Label to expect on low-priority PRs | `wont have` | `>v1.1.0`
+could-have-label | Label to expect on PRs of little relevance | `could have` | `>v1.1.0`
+should-have-label | Label to expect on non-critical PRs | `should have` | `>v1.1.0`
+must-have-label | Label to expect on essential PRs | `must have` | `>v1.1.0`
+fail-if-missing-label | Unprioritized PRs should fail the action | `true` | `deprecated`

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ MoSCoW prioritization action to manage label-based requirements prioritization
 ```yml
 name: MoSCoW Prioritization
 
-on: 
+on:
   pull_request_target:
     types: [ labeled, opened, unlabeled, reopened ]
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ MoSCoW prioritization action to manage label-based requirements prioritization
 ```yml
 name: MoSCoW Prioritization
 
-on: pull_request_target
+on: 
+  pull_request_target:
+    types: [ labeled, opened, unlabeled, reopened ]
 
 permissions:
   contents: read

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,8 @@ branding:
 inputs:
   token:
     description: 'The workflows GITHUB_TOKEN secret'
-    required: true
+    required: false
+    default: '${{ github.token }}'
   wont-have-label:
     description: 'Label to expect on low-priority PRs'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -26,10 +26,6 @@ inputs:
     description: 'Label to expect on essential PRs'
     required: false
     default: 'must have'
-  fail-if-missing-label:
-    description: 'Unprioritized PRs should fail the action'
-    required: false
-    default: 'true'
 
 runs:
   using: 'node16'

--- a/dist/index.js
+++ b/dist/index.js
@@ -45,7 +45,7 @@ Won't Have (this time) | Low priority for the current planning stage but will be
 `;
 const complete = 'Excellent, the MoSCoW prioritization is finished! :label:';
 const labels = [core.getInput('wont-have-label'), core.getInput('could-have-label'), core.getInput('should-have-label'), core.getInput('must-have-label')];
-const octo = gh.getOctokit(core.getInput('token', { required: true }));
+const octo = gh.getOctokit(core.getInput('token'));
 (async function () {
     try {
         const prNum = gh?.context?.payload?.pull_request?.number;

--- a/dist/index.js
+++ b/dist/index.js
@@ -62,6 +62,7 @@ const octo = gh.getOctokit(token);
         await octo.rest.issues.createComment({
             ...gh.context.repo, issue_number: prNum, body: exists ? complete : help
         });
+        await core.summary.addRaw(exists ? complete : help).write();
         if (!exists && fails) {
             core.setFailed('The associated pull request is currently unprioritized!');
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -45,25 +45,20 @@ Won't Have (this time) | Low priority for the current planning stage but will be
 `;
 const complete = 'Excellent, the MoSCoW prioritization is finished! :label:';
 const labels = [core.getInput('wont-have-label'), core.getInput('could-have-label'), core.getInput('should-have-label'), core.getInput('must-have-label')];
-const fails = core.getInput('fail-if-missing-label') === 'true';
-const token = core.getInput('token', { required: true });
-const octo = gh.getOctokit(token);
+const octo = gh.getOctokit(core.getInput('token', { required: true }));
 (async function () {
     try {
         const prNum = gh?.context?.payload?.pull_request?.number;
         if (prNum === undefined) {
-            core.info('This action only works on pull requests!');
+            core.notice('This action only works on pull requests!');
             return;
         }
         const { data: pr } = await octo.rest.pulls.get({
             ...gh.context.repo, pull_number: prNum
         });
         const exists = pr.labels.some(label => labels.includes(label.name));
-        await octo.rest.issues.createComment({
-            ...gh.context.repo, issue_number: prNum, body: exists ? complete : help
-        });
         await core.summary.addRaw(exists ? complete : help).write();
-        if (!exists && fails) {
+        if (!exists) {
             core.setFailed('The associated pull request is currently unprioritized!');
         }
     }

--- a/src/action.ts
+++ b/src/action.ts
@@ -15,7 +15,7 @@ Won't Have (this time) | Low priority for the current planning stage but will be
 const complete = 'Excellent, the MoSCoW prioritization is finished! :label:'
 
 const labels = [core.getInput('wont-have-label'), core.getInput('could-have-label'), core.getInput('should-have-label'), core.getInput('must-have-label')]
-const octo = gh.getOctokit(core.getInput('token', { required: true }));
+const octo = gh.getOctokit(core.getInput('token'));
 
 (async function () {
   try {

--- a/src/action.ts
+++ b/src/action.ts
@@ -15,15 +15,13 @@ Won't Have (this time) | Low priority for the current planning stage but will be
 const complete = 'Excellent, the MoSCoW prioritization is finished! :label:'
 
 const labels = [core.getInput('wont-have-label'), core.getInput('could-have-label'), core.getInput('should-have-label'), core.getInput('must-have-label')]
-const fails = core.getInput('fail-if-missing-label') === 'true'
-const token = core.getInput('token', { required: true })
-const octo = gh.getOctokit(token);
+const octo = gh.getOctokit(core.getInput('token', { required: true }));
 
 (async function () {
   try {
     const prNum = gh?.context?.payload?.pull_request?.number
     if (prNum === undefined) {
-      core.info('This action only works on pull requests!')
+      core.notice('This action only works on pull requests!')
       return
     }
 
@@ -32,14 +30,9 @@ const octo = gh.getOctokit(token);
     })
 
     const exists = pr.labels.some(label => labels.includes(label.name))
-
-    await octo.rest.issues.createComment({
-      ...gh.context.repo, issue_number: prNum, body: exists ? complete : help
-    })
-
     await core.summary.addRaw(exists ? complete : help).write()
 
-    if (!exists && fails) {
+    if (!exists) {
       core.setFailed('The associated pull request is currently unprioritized!')
     }
   } catch (error: any) {

--- a/src/action.ts
+++ b/src/action.ts
@@ -37,6 +37,8 @@ const octo = gh.getOctokit(token);
       ...gh.context.repo, issue_number: prNum, body: exists ? complete : help
     })
 
+    await core.summary.addRaw(exists ? complete : help).write()
+
     if (!exists && fails) {
       core.setFailed('The associated pull request is currently unprioritized!')
     }


### PR DESCRIPTION
__BREAKING__: Posting PR comments for prioritization changes can lead to email spam and many canceled workflow runs. Therefore, v2 should move to the newer job summary functionality offered by GitHub.

Signed-off-by: David Greven [opensource@grevend.dev](mailto:opensource@grevend.dev)